### PR TITLE
Fix composer name for current standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "bozhinov/pChart2.0-for-PHP7",
+  "name": "bozhinov/pchart2.0-for-php7",
   "description": "pChart 2.3 compatible with PHP 7",
   "keywords": [
     "php",


### PR DESCRIPTION
The name of this package is not compadable with current standards, the regex that is used is `"^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$"` which does not accept capital letters. This is throwing some composer errors under more strict enviroments.